### PR TITLE
feat: Add apps page with URL-based management

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -21,6 +21,14 @@ interface Video {
   isPublic?: boolean;
 }
 
+interface App {
+  id: string;
+  name: string;
+  description: string;
+  logoUrl: string;
+  downloadUrl: string;
+}
+
 function AdminPanel() {
   const [videos, setVideos] = useState<Video[]>([]);
   const [youtubeUrl, setYoutubeUrl] = useState('');
@@ -33,6 +41,14 @@ function AdminPanel() {
   const [visitorCount, setVisitorCount] = useState<number | null>(null);
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const router = useRouter();
+
+  // Apps state
+  const [apps, setApps] = useState<App[]>([]);
+  const [appName, setAppName] = useState('');
+  const [appDescription, setAppDescription] = useState('');
+  const [appLogoUrl, setAppLogoUrl] = useState('');
+  const [appDownloadUrl, setAppDownloadUrl] = useState('');
+  const [isUploadingApp, setIsUploadingApp] = useState(false);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (user) => {
@@ -76,10 +92,23 @@ function AdminPanel() {
     }
   }, [getAuthHeader]);
 
+  const fetchApps = useCallback(async () => {
+    try {
+      const headers = await getAuthHeader();
+      const response = await fetch('/api/apps', { headers });
+      if (!response.ok) throw new Error('Failed to fetch apps');
+      const data = await response.json();
+      setApps(data);
+    } catch (error) {
+      console.error('Failed to load apps:', error);
+    }
+  }, [getAuthHeader]);
+
   useEffect(() => {
     fetchVideos();
     fetchVisitorStats();
-  }, [fetchVideos, fetchVisitorStats]);
+    fetchApps();
+  }, [fetchVideos, fetchVisitorStats, fetchApps]);
 
   const handleAddLink = () => setRelatedLinks([...relatedLinks, { label: '', url: '' }]);
 
@@ -157,6 +186,69 @@ function AdminPanel() {
     } catch (error) {
       console.error('Logout failed:', error);
       setError('Failed to log out. Please try again.');
+    }
+  };
+
+  const handleAppSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!appName || !appLogoUrl || !appDownloadUrl) {
+      setError('App name, logo URL, and download URL are required.');
+      return;
+    }
+    setIsUploadingApp(true);
+    try {
+      const headers = await getAuthHeader();
+      const response = await fetch('/api/apps', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...headers },
+        body: JSON.stringify({
+          name: appName,
+          description: appDescription,
+          logoUrl: appLogoUrl,
+          downloadUrl: appDownloadUrl,
+        }),
+      });
+      if (!response.ok) {
+        const { message } = await response.json();
+        throw new Error(message || 'Failed to add app');
+      }
+      setAppName('');
+      setAppDescription('');
+      setAppLogoUrl('');
+      setAppDownloadUrl('');
+      fetchApps();
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        setError(error.message);
+      } else {
+        setError('An unexpected error occurred.');
+      }
+    } finally {
+      setIsUploadingApp(false);
+    }
+  };
+
+  const handleDeleteApp = async (appId: string) => {
+    setError(null);
+    try {
+      const headers = await getAuthHeader();
+      const response = await fetch('/api/apps', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json', ...headers },
+        body: JSON.stringify({ id: appId }),
+      });
+      if (!response.ok) {
+        const { message } = await response.json();
+        throw new Error(message || 'Failed to delete app');
+      }
+      fetchApps();
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        setError(error.message);
+      } else {
+        setError('An unexpected error occurred.');
+      }
     }
   };
 
@@ -265,7 +357,7 @@ function AdminPanel() {
       </Card>
 
       {/* Manage Videos */}
-      <Card>
+      <Card className="mb-8">
         <CardHeader>
           <CardTitle>Manage Videos</CardTitle>
         </CardHeader>
@@ -301,6 +393,118 @@ function AdminPanel() {
             </ul>
           ) : (
             <p>No videos found. Add one above to get started.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Add New App Form */}
+      <Card className="mb-8">
+        <CardHeader>
+          <CardTitle>Add New App</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleAppSubmit} className="space-y-6">
+            <div className="space-y-2">
+              <Label htmlFor="appName">App Name</Label>
+              <Input
+                id="appName"
+                type="text"
+                placeholder="My App"
+                value={appName}
+                onChange={(e) => setAppName(e.target.value)}
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="appDescription">Description (Optional)</Label>
+              <Input
+                id="appDescription"
+                type="text"
+                placeholder="App description"
+                value={appDescription}
+                onChange={(e) => setAppDescription(e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="appLogoUrl">App Logo URL</Label>
+              <Input
+                id="appLogoUrl"
+                type="url"
+                placeholder="https://example.com/logo.png"
+                value={appLogoUrl}
+                onChange={(e) => setAppLogoUrl(e.target.value)}
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="appDownloadUrl">App Download URL</Label>
+              <Input
+                id="appDownloadUrl"
+                type="url"
+                placeholder="https://example.com/app.apk"
+                value={appDownloadUrl}
+                onChange={(e) => setAppDownloadUrl(e.target.value)}
+                required
+              />
+            </div>
+
+            <Button type="submit" disabled={isUploadingApp}>
+              {isUploadingApp ? (
+                <>
+                  <Spinner className="h-4 w-4 mr-2" />
+                  Adding...
+                </>
+              ) : (
+                'Add App'
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {/* Manage Apps */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Manage Apps</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {apps.length > 0 ? (
+            <ul className="space-y-4">
+              {apps.map((app) => (
+                <li
+                  key={app.id}
+                  className="flex items-center justify-between p-4 border rounded-lg"
+                >
+                  <div className="flex items-center gap-4">
+                    <img
+                      src={app.logoUrl}
+                      alt={app.name}
+                      className="w-12 h-12 rounded object-cover"
+                    />
+                    <div>
+                      <p className="font-semibold">{app.name}</p>
+                      {app.description && (
+                        <p className="text-sm text-muted-foreground">
+                          {app.description}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  <Button
+                    variant="destructive"
+                    onClick={() => handleDeleteApp(app.id)}
+                  >
+                    <Trash2 className="h-4 w-4 mr-2" />
+                    Delete
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p>No apps found. Add one above to get started.</p>
           )}
         </CardContent>
       </Card>

--- a/src/app/api/apps/route.ts
+++ b/src/app/api/apps/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { adminDb } from '@/lib/firebase-admin';
+import { verifyAdmin } from '@/lib/auth';
+import { revalidatePath } from 'next/cache';
+
+// GET apps (public for all apps)
+export async function GET() {
+  try {
+    const appsQuery = adminDb.collection('apps').orderBy('createdAt', 'desc');
+    const snapshot = await appsQuery.get();
+
+    const apps = snapshot.docs.map(doc => ({
+      id: doc.id,
+      ...doc.data(),
+    }));
+
+    return NextResponse.json(apps);
+  } catch (error) {
+    console.error('Error fetching apps:', error);
+    return NextResponse.json({ message: 'Failed to fetch apps.' }, { status: 500 });
+  }
+}
+
+// POST a new app (admin only)
+export async function POST(request: NextRequest) {
+  if (!(await verifyAdmin())) {
+    return new NextResponse(JSON.stringify({ message: 'Unauthorized' }), { status: 401 });
+  }
+
+  try {
+    const { name, description, logoUrl, downloadUrl } = await request.json();
+
+    if (!name || !logoUrl || !downloadUrl) {
+      return NextResponse.json({
+        message: 'App name, logo URL, and download URL are required.'
+      }, { status: 400 });
+    }
+
+    const newApp = {
+      name,
+      description: description || '',
+      logoUrl,
+      downloadUrl,
+      createdAt: new Date(),
+    };
+
+    const docRef = await adminDb.collection('apps').add(newApp);
+
+    revalidatePath('/apps');
+
+    return NextResponse.json({
+      message: 'App added successfully.',
+      id: docRef.id
+    }, { status: 201 });
+  } catch (error: unknown) {
+    console.error('Error adding app:', error);
+    const errorMessage = error instanceof Error ? error.message : 'An unexpected error occurred.';
+    return NextResponse.json({
+      message: 'Failed to add app.',
+      error: errorMessage
+    }, { status: 500 });
+  }
+}
+
+// DELETE an app (admin only)
+export async function DELETE(request: NextRequest) {
+  if (!(await verifyAdmin())) {
+    return new NextResponse(JSON.stringify({ message: 'Unauthorized' }), { status: 401 });
+  }
+
+  try {
+    const { id } = await request.json();
+    if (!id) {
+      return NextResponse.json({ message: 'App ID is required.' }, { status: 400 });
+    }
+
+    const appDoc = await adminDb.collection('apps').doc(id).get();
+    if (!appDoc.exists) {
+      return NextResponse.json({ message: 'App not found.' }, { status: 404 });
+    }
+
+    await adminDb.collection('apps').doc(id).delete();
+
+    revalidatePath('/apps');
+
+    return NextResponse.json({ message: 'App deleted successfully.' });
+  } catch (error: unknown) {
+    console.error('Error deleting app:', error);
+    const errorMessage = error instanceof Error ? error.message : 'An unexpected error occurred.';
+    return NextResponse.json({
+      message: 'Failed to delete app.',
+      error: errorMessage
+    }, { status: 500 });
+  }
+}

--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Download } from 'lucide-react';
+import { Spinner } from '@/components/ui/spinner';
+
+interface App {
+  id: string;
+  name: string;
+  description: string;
+  logoUrl: string;
+  downloadUrl: string;
+}
+
+export default function AppsPage() {
+  const [apps, setApps] = useState<App[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchApps = async () => {
+      try {
+        const response = await fetch('/api/apps');
+        if (!response.ok) throw new Error('Failed to fetch apps');
+        const data = await response.json();
+        setApps(data);
+      } catch (error) {
+        console.error('Failed to load apps:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchApps();
+  }, []);
+
+  const handleDownload = (app: App) => {
+    window.open(app.downloadUrl, '_blank');
+  };
+
+  return (
+    <div className="container mx-auto p-4 md:p-8">
+      <div className="mb-8">
+        <h1 className="text-4xl font-bold mb-4">Apps</h1>
+        <p className="text-muted-foreground">
+          Download our apps and tools
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="flex justify-center items-center min-h-[400px]">
+          <Spinner className="h-8 w-8" />
+        </div>
+      ) : apps.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {apps.map((app) => (
+            <Card key={app.id} className="overflow-hidden hover:shadow-lg transition-shadow">
+              <CardHeader>
+                <div className="flex items-center gap-4 mb-4">
+                  <img
+                    src={app.logoUrl}
+                    alt={app.name}
+                    className="w-16 h-16 rounded-lg object-cover"
+                  />
+                  <CardTitle className="text-xl">{app.name}</CardTitle>
+                </div>
+                {app.description && (
+                  <CardDescription>{app.description}</CardDescription>
+                )}
+              </CardHeader>
+              <CardContent>
+                <Button
+                  onClick={() => handleDownload(app)}
+                  className="w-full"
+                  size="lg"
+                >
+                  <Download className="h-4 w-4 mr-2" />
+                  Download
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col items-center justify-center min-h-[400px] text-center">
+          <p className="text-xl text-muted-foreground mb-2">No apps available yet</p>
+          <p className="text-sm text-muted-foreground">Check back later for updates</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -21,6 +21,7 @@ import { ThemeToggle } from '../theme-toggle';
 const navLinks = [
   { href: '/', label: 'Home' },
   { href: '/youtube', label: 'Archives' },
+  { href: '/apps', label: 'Apps' },
   { href: '/socials', label: 'Socials' },
   { href: '/about', label: 'About' },
   { href: '/contact', label: 'Contact' },

--- a/src/lib/firebase-admin.ts
+++ b/src/lib/firebase-admin.ts
@@ -28,3 +28,4 @@ if (serviceAccount) {
 
 
 export const adminDb = admin.firestore();
+export const adminStorage = admin.storage();


### PR DESCRIPTION
- Add /apps public page displaying apps with download functionality
- Add apps management in admin panel (add/delete apps)
- Support URL-based app logo and download links
- Add Apps navigation link in navbar
- Create /api/apps route for CRUD operations
- Store app data in Firestore (name, description, logoUrl, downloadUrl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)